### PR TITLE
Update tracker layouts

### DIFF
--- a/assets/javascripts/discourse/components/group-tracker-nav.js.es6
+++ b/assets/javascripts/discourse/components/group-tracker-nav.js.es6
@@ -1,0 +1,118 @@
+import groupTrackerIcon from "discourse/plugins/discourse-group-tracker/lib/group-tracker-icon";
+import {
+  default as computed,
+  on
+} from "ember-addons/ember-computed-decorators";
+
+export default Ember.Component.extend({
+  classNames: ["group-tracker-nav"],
+
+  setCurrentPostNumber({ post }) {
+    this.set("currentPostNumber", post.post_number);
+  },
+
+  @on("init")
+  init() {
+    this._super(...arguments);
+    this.set("currentPostNumber", 1);
+    this.appEvents.on(
+      "topic:current-post-changed",
+      this,
+      "setCurrentPostNumber"
+    );
+  },
+
+  @on("destroy")
+  destroy() {
+    this.appEvents.off(
+      "topic:current-post-changed",
+      this,
+      "setCurrentPostNumber"
+    );
+  },
+
+  getPreviousTrackedPost() {
+    const topic = this.topic;
+    const postStream = topic.get("postStream");
+    const stream = postStream.get("stream");
+
+    return (
+      topic &&
+      topic.tracked_posts &&
+      topic.tracked_posts
+        .filter(p => {
+          return (
+            p.post_number < this.currentPostNumber &&
+            stream.includes(postStream.findPostIdForPostNumber(p.post_number))
+          );
+        })
+        .pop()
+    );
+  },
+
+  getNextTrackedPost() {
+    const topic = this.topic;
+    const postStream = topic.get("postStream");
+    const stream = postStream.get("stream");
+
+    return (
+      topic &&
+      topic.tracked_posts &&
+      topic.tracked_posts.find(p => {
+        return (
+          p.post_number > this.currentPostNumber &&
+          stream.includes(postStream.findPostIdForPostNumber(p.post_number))
+        );
+      })
+    );
+  },
+
+  @computed("topic", "currentPostNumber")
+  nextTrackedPostGroup(topic) {
+    const nextTrackedPost = this.getNextTrackedPost(topic);
+    return nextTrackedPost ? nextTrackedPost.group : null;
+  },
+
+  @computed("nextTrackedPostGroup", "currentPostNumber")
+  nextTrackerIcon(nextTrackedPostGroup, currentPostNumber) {
+    return groupTrackerIcon(nextTrackedPostGroup, this.site, this.siteSettings);
+  },
+
+  @computed("nextTrackedPostGroup", "currentPostNumber")
+  nextTrackedPostDisabled(nextTrackedPostGroup) {
+    return nextTrackedPostGroup === null;
+  },
+
+  @computed("topic", "currentPostNumber")
+  prevTrackedPostGroup(topic) {
+    const prevTrackedPost = this.getPreviousTrackedPost(topic);
+    return prevTrackedPost ? prevTrackedPost.group : null;
+  },
+
+  @computed("prevTrackedPostGroup", "currentPostNumber")
+  prevTrackerIcon(prevTrackedPostGroup) {
+    return groupTrackerIcon(prevTrackedPostGroup, this.site, this.siteSettings);
+  },
+
+  @computed("prevTrackedPostGroup", "currentPostNumber")
+  prevTrackedPostDisabled(prevTrackedPostGroup) {
+    return prevTrackedPostGroup === null;
+  },
+
+  actions: {
+    jumpToNextTrackedPost() {
+      const nextTrackedPost = this.getNextTrackedPost(topic);
+
+      if (nextTrackedPost) {
+        this.jumpToPost(nextTrackedPost.post_number);
+      }
+    },
+    jumpToPrevTrackedPost() {
+      const prevTrackedPost = this.getPreviousTrackedPost(topic);
+
+      if (prevTrackedPost) {
+        this.jumpToPost(prevTrackedPost.post_number);
+      }
+    }
+  }
+});

--- a/assets/javascripts/discourse/templates/components/group-tracker-nav.hbs
+++ b/assets/javascripts/discourse/templates/components/group-tracker-nav.hbs
@@ -1,0 +1,16 @@
+{{#d-button
+  action=(action "jumpToPrevTrackedPost")
+  class="btn-default group-tracker-jump-prev"
+  icon=prevTrackerIcon
+  disabled=prevTrackedPostDisabled
+}}
+  {{d-icon 'arrow-left'}}
+{{/d-button}}
+{{#d-button
+  action=(action "jumpToNextTrackedPost")
+  class="btn-default group-tracker-jump-next"
+  icon=nextTrackerIcon
+  disabled=nextTrackedPostDisabled
+}}
+  {{d-icon 'arrow-right'}}
+{{/d-button}}

--- a/assets/javascripts/discourse/templates/connectors/before-topic-progress/group-tracker.hbs
+++ b/assets/javascripts/discourse/templates/connectors/before-topic-progress/group-tracker.hbs
@@ -1,0 +1,1 @@
+{{group-tracker-nav topic=model jumpToPost=jumpToPost}}

--- a/assets/stylesheets/group-tracker.scss
+++ b/assets/stylesheets/group-tracker.scss
@@ -1,0 +1,9 @@
+.group-tracker-nav {
+  background-color: $secondary;
+  padding: 6px 12px;
+  display: inline-flex;
+  .btn {
+    height: 35px;
+    display: inline-flex;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -16,4 +16,5 @@ en:
       first_group_post: "First %{group} post"
 
       next_post: "Next tracked post"
+      prev_post: "Previous tracked post"
       next_group_post: "Next %{group} post"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 plugins:
   group_tracker_default_icon:
     client: true
-    default: "arrow-circle-right"
+    default: "crown"
   group_tracker_topic_icon:
     client: true
     default: ""

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,9 +1,12 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 # name: discourse-group-tracker
 # about: Group Tracker plugin for Discourse
 # version: 0.1
 # author: Régis Hanol
+
+register_asset 'stylesheets/group-tracker.scss'
 
 after_initialize do
 
@@ -22,6 +25,9 @@ after_initialize do
   register_group_custom_field_type(GroupTracker.key("add_to_navigation_bar"), :boolean)
 
   register_svg_icon 'arrow-circle-up' if respond_to?(:register_svg_icon)
+  register_svg_icon 'crown' if respond_to?(:register_svg_icon)
+  register_svg_icon 'arrow-right' if respond_to?(:register_svg_icon)
+  register_svg_icon 'arrow-left' if respond_to?(:register_svg_icon)
 
   GroupTracker::GROUP_ATTRIBUTES.each do |attribute|
     add_preloaded_group_custom_field(GroupTracker.key(attribute))


### PR DESCRIPTION
Add prev post button nav

Always show post jump buttons, but disable them when there are no more

Disable the jump to first tracked post button when we are above the first post.

Add a group tracker nav element to the mobile post navigation

Default icon as a crown as it looks confusing with many arrows

Desktop view:
![Screen Shot 2019-09-04 at 6 17 21 PM](https://user-images.githubusercontent.com/1322534/64304345-5f957e00-cf40-11e9-825d-74dac34c0903.png)

Mobile view:
![Screen Shot 2019-09-04 at 6 17 49 PM](https://user-images.githubusercontent.com/1322534/64304346-5f957e00-cf40-11e9-96fa-6cb1b738a4ee.png)

Mobile view with open timeline:
![Screen Shot 2019-09-04 at 6 18 00 PM](https://user-images.githubusercontent.com/1322534/64304347-5f957e00-cf40-11e9-8ad0-d74ec8f3d44c.png)
