### PR TITLE
DEV: Do not lookup using stale container

### DIFF
--- a/assets/javascripts/discourse/initializers/initialize-group-tracker.js
+++ b/assets/javascripts/discourse/initializers/initialize-group-tracker.js
@@ -5,6 +5,7 @@ import Composer from "discourse/models/composer";
 import groupTrackerIcon from "discourse/plugins/discourse-group-tracker/lib/group-tracker-icon";
 import DiscourseURL from "discourse/lib/url";
 import getURL from "discourse-common/lib/get-url";
+import { getOwner } from "discourse-common/lib/get-owner";
 
 const PLUGIN_ID = "discourse-group-tracker";
 
@@ -261,7 +262,7 @@ function addOptOutToggle(api) {
     pluginId: PLUGIN_ID,
 
     beforeCreate(props) {
-      const composerController = api.container.lookup("controller:composer");
+      const composerController = getOwner(this).lookup("controller:composer");
 
       if (composerController.get("model.optedOut")) {
         props.opted_out = true;


### PR DESCRIPTION
In tests, a new container is created for each test. `modifyClass` changes are applied only on the first test run, so `api.container` will always refer to the first container. Looking up `controller:composer` in later test runs will therefore trigger an error.

Instead, we can use `getOwner` to fetch the current container at runtime.