### PR TITLE
FIX: jump to first post (pre-glimmer)

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,1 +1,2 @@
-2.9.0.beta10: d0f23c223a20f6d8f854665408c3595d87f61191
+# branch: pre-glimmer
+2.9.0.beta10: db15417a32915251f9ecea9901d04d9b415cecbf


### PR DESCRIPTION
Fix for pre-discourse 3.0. Correctly jump to first post.

Commit here: https://github.com/discourse/discourse-group-tracker/commit/db15417a32915251f9ecea9901d04d9b415cecbf