### PR TITLE
DEV: Drop topic-timeline widget customizations and bump version

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,3 @@
+3.1.0.beta1: f91af69ec4b89333e8d2727ce5bb8eea004ab8dc
 # branch: pre-glimmer
 2.9.0.beta10: db15417a32915251f9ecea9901d04d9b415cecbf

--- a/assets/javascripts/discourse/initializers/initialize-group-tracker.js
+++ b/assets/javascripts/discourse/initializers/initialize-group-tracker.js
@@ -1,9 +1,7 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { iconNode } from "discourse-common/lib/icon-library";
 import computed from "discourse-common/utils/decorators";
 import Composer from "discourse/models/composer";
 import groupTrackerIcon from "discourse/plugins/discourse-group-tracker/lib/group-tracker-icon";
-import DiscourseURL from "discourse/lib/url";
 import getURL from "discourse-common/lib/get-url";
 import { getOwner } from "discourse-common/lib/get-owner";
 
@@ -58,140 +56,6 @@ function addNavigationBarItems(api) {
         includeCategoryId: true,
       });
     });
-}
-
-function addControlToTimeline(api) {
-  const appEvents = api.container.lookup("service:app-events");
-
-  let currentPostNumber = 1;
-
-  appEvents.on("topic:current-post-changed", ({ post }) => {
-    currentPostNumber = post.post_number;
-  });
-
-  api.decorateWidget("timeline-controls:before", (helper) => {
-    const { topic } = helper.attrs;
-    if (topic.first_tracked_post) {
-      return helper.attach("button", {
-        className: "first-tracked-post",
-        icon: "arrow-circle-up",
-        title: "group_tracker.first_post",
-        action: "jumpToFirstTrackedPost",
-        disabled: topic.first_tracked_post.post_number >= currentPostNumber,
-      });
-    }
-  });
-
-  api.reopenWidget("timeline-controls", {
-    jumpToFirstTrackedPost() {
-      const { topic } = this.attrs;
-      if (topic.first_tracked_post) {
-        DiscourseURL.jumpToPost(topic.first_tracked_post.post_number);
-      }
-    },
-  });
-
-  function getPreviousTrackedPost(topic) {
-    const postStream = topic.get("postStream");
-    const stream = postStream.get("stream");
-
-    return (
-      topic &&
-      topic.tracked_posts &&
-      topic.tracked_posts
-        .filter((p) => {
-          return (
-            p.post_number < currentPostNumber &&
-            stream.includes(postStream.findPostIdForPostNumber(p.post_number))
-          );
-        })
-        .pop()
-    );
-  }
-
-  function getNextTrackedPost(topic) {
-    const postStream = topic.get("postStream");
-    const stream = postStream.get("stream");
-
-    return (
-      topic &&
-      topic.tracked_posts &&
-      topic.tracked_posts.find((p) => {
-        return (
-          p.post_number > currentPostNumber &&
-          stream.includes(postStream.findPostIdForPostNumber(p.post_number))
-        );
-      })
-    );
-  }
-
-  api.decorateWidget("timeline-footer-controls:after", (helper) => {
-    const { topic } = helper.attrs;
-    const { site, siteSettings } = helper.widget;
-    const nextTrackedPost = getNextTrackedPost(topic);
-    const prevTrackedPost = getPreviousTrackedPost(topic);
-    const group = prevTrackedPost ? prevTrackedPost.group : null;
-    const nextGroup = nextTrackedPost ? nextTrackedPost.group : null;
-
-    //if both buttons are disabled, do not display
-    if (group === null && nextGroup === null) {
-      return null;
-    }
-
-    return helper.attach("button", {
-      className: "prev-tracked-post",
-      icon: groupTrackerIcon(group, site, siteSettings),
-      contents: iconNode("arrow-left"),
-      title: "group_tracker.prev_post",
-      action: "jumpToPrevTrackedPost",
-      disabled: group === null,
-    });
-  });
-
-  api.decorateWidget("timeline-footer-controls:after", (helper) => {
-    const { topic } = helper.attrs;
-    const { site, siteSettings } = helper.widget;
-    const nextTrackedPost = getNextTrackedPost(topic);
-    const prevTrackedPost = getPreviousTrackedPost(topic);
-    const group = nextTrackedPost ? nextTrackedPost.group : null;
-    const prevGroup = prevTrackedPost ? prevTrackedPost.group : null;
-
-    //if both buttons are disabled, do not display
-    if (group === null && prevGroup === null) {
-      return null;
-    }
-
-    return helper.attach("button", {
-      className: "next-tracked-post",
-      icon: groupTrackerIcon(group, site, siteSettings),
-      contents: iconNode("arrow-right"),
-      title: "group_tracker.next_post",
-      action: "jumpToNextTrackedPost",
-      disabled: group === null,
-    });
-  });
-
-  api.reopenWidget("timeline-footer-controls", {
-    jumpToNextTrackedPost() {
-      const { topic } = this.attrs;
-      const nextTrackedPost = getNextTrackedPost(topic);
-
-      if (nextTrackedPost) {
-        const url = topic.url + "/" + nextTrackedPost.post_number;
-        DiscourseURL.routeTo(url);
-      }
-    },
-
-    jumpToPrevTrackedPost() {
-      const { topic } = this.attrs;
-      const prevTrackedPost = getPreviousTrackedPost(topic);
-
-      if (prevTrackedPost) {
-        const url = topic.url + "/" + prevTrackedPost.post_number;
-        DiscourseURL.routeTo(url);
-      }
-    },
-  });
 }
 
 function addOptOutClassOnPost(api) {
@@ -283,11 +147,7 @@ export default {
   initialize() {
     withPluginApi("0.8.9", (api) => {
       modifyTopicModel(api);
-
       addNavigationBarItems(api);
-
-      addControlToTimeline(api);
-
       addOptOutClassOnPost(api);
       addOptOutToggle(api);
       addTrackedGroupToTopicList(api);


### PR DESCRIPTION
# Context

We have removed the topic-timeline widget implementation from core which causes errors when trying to lookup the widget implementation. eg:

```
api.decorateWidget("timeline-controls:before"
```

# Solution
Remove `addControlToTimeline` and its widget decoration calls in favor of https://github.com/discourse/discourse-group-tracker/commit/39329f33797a94737d3e3ccc2931e162545214e0

# Additional
Add discourse-compatibility record for plugin bump

