### PR TITLE
Update .discourse-compatibility

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,3 @@
-3.1.0.beta1: f91af69ec4b89333e8d2727ce5bb8eea004ab8dc
+3.1.0.beta1: ebdbf973777985df7efa266d8d1d1198ce112940
 # branch: pre-glimmer
 2.9.0.beta10: db15417a32915251f9ecea9901d04d9b415cecbf


### PR DESCRIPTION
The change made in 5e5acccdd978b4f7ffcb040b6dc919760fd0b280 pointed at a non-existent commit in this plugin.

@janzenisaac Can you confirm that this is what you wanted to do by updating the `.discourse-compatibility` file?