### PR TITLE
FIX: jump targets inside a topic list when using priority groups

### DIFF
--- a/assets/javascripts/discourse/components/group-tracker-first-post.js
+++ b/assets/javascripts/discourse/components/group-tracker-first-post.js
@@ -7,8 +7,10 @@ export default class GroupTrackerFirstPost extends Component {
   @readOnly("args.topic.currentPost") postId;
 
   get disabled() {
-    if (this.args.topic.first_tracked_post) {
-      return this.args.topic.first_tracked_post.post_number >= this.postId;
+    const topic = this.args.topic;
+    if (topic.first_tracked_post) {
+      const jump_target = topic.first_tracked_post.jump_target || topic.first_tracked_post.post_number;
+      return jump_target >= this.postId;
     }
     return null;
   }
@@ -17,7 +19,8 @@ export default class GroupTrackerFirstPost extends Component {
   jumpToFirstTrackedPost() {
     const topic = this.args.topic;
     if (topic.first_tracked_post) {
-      DiscourseURL.jumpToPost(topic.first_tracked_post.post_number);
+      const jump_target = topic.first_tracked_post.jump_target || topic.first_tracked_post.post_number;
+      DiscourseURL.jumpToPost(jump_target);
     }
   }
 }

--- a/assets/javascripts/discourse/components/group-tracker-first-post.js
+++ b/assets/javascripts/discourse/components/group-tracker-first-post.js
@@ -9,7 +9,9 @@ export default class GroupTrackerFirstPost extends Component {
   get disabled() {
     const topic = this.args.topic;
     if (topic.first_tracked_post) {
-      const jump_target = topic.first_tracked_post.jump_target || topic.first_tracked_post.post_number;
+      const jump_target =
+        topic.first_tracked_post.jump_target ||
+        topic.first_tracked_post.post_number;
       return jump_target >= this.postId;
     }
     return null;
@@ -19,7 +21,9 @@ export default class GroupTrackerFirstPost extends Component {
   jumpToFirstTrackedPost() {
     const topic = this.args.topic;
     if (topic.first_tracked_post) {
-      const jump_target = topic.first_tracked_post.jump_target || topic.first_tracked_post.post_number;
+      const jump_target =
+        topic.first_tracked_post.jump_target ||
+        topic.first_tracked_post.post_number;
       DiscourseURL.jumpToPost(jump_target);
     }
   }

--- a/lib/group_tracker.rb
+++ b/lib/group_tracker.rb
@@ -43,20 +43,19 @@ module GroupTracker
 
   def self.update_tracking_on_topics!(topic_id = nil)
     builder = DB.build <<~SQL
-        WITH
-"first_tracked_post_number" AS (
-SELECT p.topic_id
-, row_number() OVER (PARTITION BY p.topic_id ORDER BY p.topic_id, p.id) "row"
-, p.post_number
-, p.id "post_id"
-, u.primary_group_id "group_id"
-FROM "posts" p
-JOIN "users" u  ON u.id = p.user_id
-JOIN "topics" t ON t.id = p.topic_id
-LEFT JOIN "post_custom_fields" pcf ON pcf.post_id = p.id AND pcf.name = :opted_out_name
-/*where*/
-ORDER BY p.topic_id, p.id
-), "tracked_posts_priority" AS (
+        WITH "first_tracked_post_number" AS (
+            SELECT p.topic_id
+                 , row_number() OVER (PARTITION BY p.topic_id ORDER BY p.topic_id, p.id) "row"
+                 , p.post_number
+                 , p.id "post_id"
+                 , u.primary_group_id "group_id"
+              FROM "posts" p
+              JOIN "users" u  ON u.id = p.user_id
+              JOIN "topics" t ON t.id = p.topic_id
+              LEFT JOIN "post_custom_fields" pcf ON pcf.post_id = p.id AND pcf.name = :opted_out_name
+              /*where*/
+              ORDER BY p.topic_id, p.id
+            ), "tracked_posts_priority" AS (
             SELECT p.topic_id
                  , row_number() OVER (PARTITION BY p.topic_id ORDER BY p.topic_id, p.id) "row"
                  , p.post_number

--- a/spec/integration/group_tracking_spec.rb
+++ b/spec/integration/group_tracking_spec.rb
@@ -83,6 +83,7 @@ describe "Group Tracking" do
       expect(topic.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => group.name,
         "post_number" => 1,
+        "jump_target" => 1,
       )
       expect(post1.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => group.name,
@@ -126,6 +127,7 @@ describe "Group Tracking" do
       expect(topic.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => tracked_group.name,
         "post_number" => 2,
+        "jump_target" => 2,
       )
 
       expect(topic.ordered_posts[1].custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
@@ -149,6 +151,7 @@ describe "Group Tracking" do
         expect(topic.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => tracked_group.name,
           "post_number" => 1,
+          "jump_target" => 1,
         )
 
         sign_in(priority_member)
@@ -159,6 +162,7 @@ describe "Group Tracking" do
         expect(topic.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => priority_tracked_group.name,
           "post_number" => 2,
+          "jump_target" => 1,
         )
       end
     end
@@ -174,6 +178,7 @@ describe "Group Tracking" do
         expect(topic.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => tracked_group.name,
           "post_number" => 1,
+          "jump_target" => 1,
         )
 
         sign_in(member3)
@@ -184,6 +189,7 @@ describe "Group Tracking" do
         expect(topic.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => tracked_group.name,
           "post_number" => 1,
+          "jump_target" => 1,
         )
       end
     end
@@ -215,6 +221,7 @@ describe "Group Tracking" do
       expect(topic.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => tracked_group.name,
         "post_number" => 1,
+        "jump_target" => 1,
       )
       expect(post1.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => tracked_group.name,
@@ -245,6 +252,7 @@ describe "Group Tracking" do
         expect(topic.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => tracked_group.name,
           "post_number" => 1,
+          "jump_target" => 1,
         )
         expect(post1.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => tracked_group.name,
@@ -264,6 +272,7 @@ describe "Group Tracking" do
         expect(topic.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => priority_tracked_group.name,
           "post_number" => 3,
+          "jump_target" => 1,
         )
       end
     end
@@ -289,6 +298,7 @@ describe "Group Tracking" do
         expect(topic.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => tracked_group.name,
           "post_number" => 1,
+          "jump_target" => 1,
         )
         expect(post1.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => tracked_group.name,
@@ -308,6 +318,7 @@ describe "Group Tracking" do
         expect(topic.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => tracked_group.name,
           "post_number" => 1,
+          "jump_target" => 1,
         )
       end
     end
@@ -332,6 +343,7 @@ describe "Group Tracking" do
       expect(topic.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => tracked_group.name,
         "post_number" => 3,
+        "jump_target" => 3,
       )
       expect(post1.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to be(nil)
       expect(post3.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to be(nil)
@@ -339,6 +351,7 @@ describe "Group Tracking" do
       expect(destination_topic.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => tracked_group.name,
         "post_number" => 1,
+        "jump_target" => 1,
       )
       expect(post2.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to be(nil)
     end
@@ -358,6 +371,7 @@ describe "Group Tracking" do
         expect(topic.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => tracked_group.name,
           "post_number" => 2,
+          "jump_target" => 2,
         )
         expect(post1.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to be(nil)
         expect(post3.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to be(nil)
@@ -365,6 +379,7 @@ describe "Group Tracking" do
         expect(destination_topic.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
           "group" => priority_tracked_group.name,
           "post_number" => 1,
+          "jump_target" => 1,
         )
 
         expect(post2.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
@@ -388,6 +403,7 @@ describe "Group Tracking" do
       expect(topic.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => tracked_group.name,
         "post_number" => 3,
+        "jump_target" => 3,
       )
       expect(post1.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to be(nil)
       expect(post2.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to be(nil)
@@ -421,6 +437,7 @@ describe "Group Tracking" do
       expect(topic1.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => tracked_group.name,
         "post_number" => 1,
+        "jump_target" => 1,
       )
       expect(post1_1.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => tracked_group.name,
@@ -432,6 +449,7 @@ describe "Group Tracking" do
       expect(topic2.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => tracked_group.name,
         "post_number" => 1,
+        "jump_target" => 1,
       )
       expect(post2_1.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => tracked_group.name,
@@ -452,6 +470,7 @@ describe "Group Tracking" do
       expect(topic2.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(
         "group" => tracked_group.name,
         "post_number" => 2,
+        "jump_target" => 2,
       )
       expect(post2_1.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to be(nil)
       expect(post2_2.reload.custom_fields[GroupTracker::TRACKED_POSTS]).to eq(


### PR DESCRIPTION
On a topic list, the post number target makes sense to navigate to the priority group's post directly.

However, this causes an issue when inside the topic as it will appear that all tracked posts prior to the post are gone (IE: lower priority posts made before).

Update functionality to have two jump targets: one from outside the topic to the priority group's post, and another when jumping to the first tracked post within a topic.