### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/group-tracker-first-post.hbs
+++ b/assets/javascripts/discourse/components/group-tracker-first-post.hbs
@@ -1,7 +1,7 @@
 {{#if @topic.first_tracked_post}}
   <DButton
     class="first-tracked-post"
-    @icon="arrow-circle-up"
+    @icon="circle-arrow-up"
     @title="group_tracker.first_post"
     @disabled={{this.disabled}}
     @action={{action "jumpToFirstTrackedPost"}}


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.