### PR TITLE
DEV: Added compatibility with the Glimmer Post Stream

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.5.0.beta8-dev: 6671e6e62e68dacdf9a78e02cd65d8d522eb4d04
 < 3.5.0.beta5-dev: 57547deff687f4ada888d8bb88cd7c5eabf0e516
 < 3.5.0.beta3-dev: f4f2537cef9a178b27b53999afe37e6cb36d02c9
 < 3.5.0.beta1-dev: 4f61cc0e7b972852d21af401a6eb9d331844fa01

--- a/assets/javascripts/discourse/initializers/initialize-group-tracker.js
+++ b/assets/javascripts/discourse/initializers/initialize-group-tracker.js
@@ -57,7 +57,7 @@ function addNavigationBarItems(api) {
 }
 
 function addOptOutClassOnPost(api) {
-  api.includePostAttributes("opted_out");
+  api.addTrackedPostProperties("opted_out");
   api.addPostClassesCallback((p) => p.opted_out && ["opted-out"]);
 }
 


### PR DESCRIPTION
This pull request updates the group tracker plugin to ensure compatibility with the Glimmer Post Stream. Specifically:
- Replaces the deprecated `includePostAttributes` with the new `addTrackedPostProperties` method as per the latest plugin API.
- Updates the `.discourse-compatibility` file to reflect support for Discourse versions `< 3.5.0.beta8-dev`.

These changes ensure that the plugin continues to work with recent core updates and avoids deprecated API usage.