### PR TITLE
UX: revert "Make docked container always shown for group tracker"

### DIFF
--- a/assets/stylesheets/group-tracker.scss
+++ b/assets/stylesheets/group-tracker.scss
@@ -1,9 +1,3 @@
-.timeline-container.timeline-docked-bottom .timeline-footer-controls {
-  opacity: 1;
-  pointer-events: auto;
-  cursor: pointer;
-}
-
 .group-tracker-nav {
   background-color: var(--secondary);
   display: inline-flex;


### PR DESCRIPTION
Reverts discourse/discourse-group-tracker#92

This issue got fixed in core


https://github.com/user-attachments/assets/c4ead6d4-4fad-4c2f-96c4-9c517852233a

