### PR TITLE
A11Y: add aria-labels to timeline nav buttons

### DIFF
--- a/assets/javascripts/discourse/components/group-tracker-first-post.gjs
+++ b/assets/javascripts/discourse/components/group-tracker-first-post.gjs
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import { readOnly } from "@ember/object/computed";
 import DButton from "discourse/components/d-button";
 import DiscourseURL from "discourse/lib/url";
+import { i18n } from "discourse-i18n";
 
 export default class GroupTrackerFirstPost extends Component {
   @readOnly("args.topic.currentPost") postId;
@@ -37,6 +38,7 @@ export default class GroupTrackerFirstPost extends Component {
         @title="group_tracker.first_post"
         @disabled={{this.disabled}}
         @action={{this.jumpToFirstTrackedPost}}
+        ariaLabel={{i18n "js.group_tracker.first_post"}}
       />
     {{/if}}
   </template>

--- a/assets/javascripts/discourse/components/group-tracker-nav.gjs
+++ b/assets/javascripts/discourse/components/group-tracker-nav.gjs
@@ -6,6 +6,7 @@ import DButton from "discourse/components/d-button";
 import icon from "discourse/helpers/d-icon";
 import DiscourseURL from "discourse/lib/url";
 import groupTrackerIcon from "discourse/plugins/discourse-group-tracker/lib/group-tracker-icon";
+import { i18n } from "discourse-i18n";
 
 export default class GroupTrackerNav extends Component {
   @service site;
@@ -90,6 +91,22 @@ export default class GroupTrackerNav extends Component {
     return this.prevTrackedPostGroup === null;
   }
 
+  get ariaLabelPrevPost() {
+    return this.prevTrackedPostGroup
+      ? i18n("js.group_tracker.prev_group_post", {
+          group: this.prevTrackedPostGroup,
+        })
+      : i18n("js.group_tracker.prev_post");
+  }
+
+  get ariaLabelNextPost() {
+    return this.nextTrackedPostGroup
+      ? i18n("js.group_tracker.next_group_post", {
+          group: this.nextTrackedPostGroup,
+        })
+      : i18n("js.group_tracker.next_post");
+  }
+
   @action
   jumpToNextTrackedPost() {
     const nextTrackedPost = this.getNextTrackedPost();
@@ -118,6 +135,7 @@ export default class GroupTrackerNav extends Component {
           @action={{this.jumpToPrevTrackedPost}}
           @icon={{this.prevTrackerIcon}}
           @disabled={{this.prevTrackedPostDisabled}}
+          ariaLabel={{this.ariaLabelPrevPost}}
         >
           {{icon "arrow-left"}}
         </DButton>
@@ -126,6 +144,7 @@ export default class GroupTrackerNav extends Component {
           @action={{this.jumpToNextTrackedPost}}
           @icon={{this.nextTrackerIcon}}
           @disabled={{this.nextTrackedPostDisabled}}
+          ariaLabel={{this.ariaLabelNextPost}}
         >
           {{icon "arrow-right"}}
         </DButton>

--- a/assets/javascripts/discourse/components/group-tracker-nav.gjs
+++ b/assets/javascripts/discourse/components/group-tracker-nav.gjs
@@ -5,8 +5,8 @@ import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import icon from "discourse/helpers/d-icon";
 import DiscourseURL from "discourse/lib/url";
-import groupTrackerIcon from "discourse/plugins/discourse-group-tracker/lib/group-tracker-icon";
 import { i18n } from "discourse-i18n";
+import groupTrackerIcon from "discourse/plugins/discourse-group-tracker/lib/group-tracker-icon";
 
 export default class GroupTrackerNav extends Component {
   @service site;

--- a/assets/stylesheets/group-tracker.scss
+++ b/assets/stylesheets/group-tracker.scss
@@ -2,12 +2,18 @@
   background-color: var(--secondary);
   display: inline-flex;
   height: 100%;
+  gap: 0.5em;
 
   .btn {
     display: inline-flex;
+    gap: 0.15em;
   }
 }
 
 .group-tracker {
   height: 100%;
+}
+
+.group-tracker-jump-prev {
+  flex-direction: row-reverse;
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -19,3 +19,4 @@ en:
       next_post: "Next tracked post"
       prev_post: "Previous tracked post"
       next_group_post: "Next %{group} post"
+      prev_group_post: "Previous %{group} post"


### PR DESCRIPTION
This adds proper aria-labels to the group tracker buttons in the timeline. I've also added some missing space.


Before: 

<img height="500" alt="image" src="https://github.com/user-attachments/assets/0352b1bb-322c-4b4b-9308-fd95b8c31ec8" />



After: 

<img  height="500" alt="image" src="https://github.com/user-attachments/assets/9120e03d-f869-4cf7-908f-54cd6d96dc5e" />
