### PR TITLE
UX: Add missing aria label character and title to timeline nav button

### DIFF
--- a/assets/javascripts/discourse/components/group-tracker-nav.gjs
+++ b/assets/javascripts/discourse/components/group-tracker-nav.gjs
@@ -135,7 +135,8 @@ export default class GroupTrackerNav extends Component {
           @action={{this.jumpToPrevTrackedPost}}
           @icon={{this.prevTrackerIcon}}
           @disabled={{this.prevTrackedPostDisabled}}
-          ariaLabel={{this.ariaLabelPrevPost}}
+          @ariaLabel={{this.ariaLabelPrevPost}}
+          @title={{this.ariaLabelPrevPost}}
         >
           {{icon "arrow-left"}}
         </DButton>
@@ -144,7 +145,8 @@ export default class GroupTrackerNav extends Component {
           @action={{this.jumpToNextTrackedPost}}
           @icon={{this.nextTrackerIcon}}
           @disabled={{this.nextTrackedPostDisabled}}
-          ariaLabel={{this.ariaLabelNextPost}}
+          @ariaLabel={{this.ariaLabelNextPost}}
+          @title={{this.ariaLabelNextPost}}
         >
           {{icon "arrow-right"}}
         </DButton>

--- a/assets/javascripts/discourse/components/group-tracker-nav.gjs
+++ b/assets/javascripts/discourse/components/group-tracker-nav.gjs
@@ -135,8 +135,8 @@ export default class GroupTrackerNav extends Component {
           @action={{this.jumpToPrevTrackedPost}}
           @icon={{this.prevTrackerIcon}}
           @disabled={{this.prevTrackedPostDisabled}}
-          @ariaLabel={{this.ariaLabelPrevPost}}
-          @title={{this.ariaLabelPrevPost}}
+          aria-label={{this.ariaLabelPrevPost}}
+          title={{this.ariaLabelPrevPost}}
         >
           {{icon "arrow-left"}}
         </DButton>

--- a/assets/javascripts/discourse/components/group-tracker-nav.gjs
+++ b/assets/javascripts/discourse/components/group-tracker-nav.gjs
@@ -145,8 +145,8 @@ export default class GroupTrackerNav extends Component {
           @action={{this.jumpToNextTrackedPost}}
           @icon={{this.nextTrackerIcon}}
           @disabled={{this.nextTrackedPostDisabled}}
-          @ariaLabel={{this.ariaLabelNextPost}}
-          @title={{this.ariaLabelNextPost}}
+          aria-label={{this.ariaLabelNextPost}}
+          title={{this.ariaLabelNextPost}}
         >
           {{icon "arrow-right"}}
         </DButton>


### PR DESCRIPTION
per: https://meta.discourse.org/t/group-tracker-plugin-aria-labels-are-missing/380910

<img width="198" height="521" alt="Screenshot 2025-09-01 at 16 05 39" src="https://github.com/user-attachments/assets/3483091c-4af7-44cc-b23d-4b2d993ba4ac" />
