### PR TITLE
DEV: Warn that tracking a group makes it publicly visible

### DIFF
--- a/assets/javascripts/discourse/connectors/group-edit/group-tracker-group-edit.gjs
+++ b/assets/javascripts/discourse/connectors/group-edit/group-tracker-group-edit.gjs
@@ -35,6 +35,10 @@ export default class GroupTrackerGroupEdit extends Component {
           {{i18n "group_tracker.track_posts"}}
         </label>
 
+        <div class="control-instructions">
+          {{i18n "group_tracker.track_posts_warning"}}
+        </div>
+
         <label>
           <Input
             {{on

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2,6 +2,7 @@ en:
   js:
     group_tracker:
       track_posts: "Track posts made by members of this group"
+      track_posts_warning: "Tracking a group makes its name and membership publicly visible, even if the group's visibility is otherwise restricted."
       track_posts_with_priority: "Display this group's icon in the topic list even when another tracked group user has replied first."
       add_to_navigation_bar: "Add to navigation bar"
 


### PR DESCRIPTION
Tracked groups are intentionally surfaced in `/site.json` and on members' posts, so enabling tracking effectively makes a group's name and membership **public** — even when the group's `visibility_level` is otherwise restricted.

This is by design (tracking is an admin-only action whose whole purpose is to publicise a group's posts), so instead of filtering the list we add a short warning in the group editor, under the "Track posts" toggle, to make the trade-off clear before an admin enables it:

> Tracking a group makes its name and membership publicly visible, even if the group's visibility is otherwise restricted.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)