### PR TITLE
DEV: adds indexes to post_custom_fields

### DIFF
--- a/db/migrate/20260729000001_add_group_tracker_post_custom_fields_indexes.rb
+++ b/db/migrate/20260729000001_add_group_tracker_post_custom_fields_indexes.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+class AddGroupTrackerPostCustomFieldsIndexes < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS index_post_custom_fields_on_group_tracker_tracked_posts
+    SQL
+    execute <<~SQL
+      CREATE INDEX CONCURRENTLY index_post_custom_fields_on_group_tracker_tracked_posts
+      ON post_custom_fields (post_id)
+      WHERE name = 'group_tracker_tracked_posts'
+    SQL
+
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS index_post_custom_fields_on_group_tracker_opted_out
+    SQL
+    execute <<~SQL
+      CREATE INDEX CONCURRENTLY index_post_custom_fields_on_group_tracker_opted_out
+      ON post_custom_fields (post_id)
+      WHERE name = 'group_tracker_opted_out'
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      DROP INDEX IF EXISTS index_post_custom_fields_on_group_tracker_tracked_posts
+    SQL
+    execute <<~SQL
+      DROP INDEX IF EXISTS index_post_custom_fields_on_group_tracker_opted_out
+    SQL
+  end
+end


### PR DESCRIPTION
As the queries in `lib/group_tracker.rb` JOIN across multiple tables to `post_custom_fields`, a poor query across post_custom_fields can negatively impact performance. As this plugin only needs the values for `group_tracker_tracked_posts`, `group_tracker_opted_out`, only two indexes are needed.